### PR TITLE
Added a flag bEntropyTableInit which is FALSE if no entropy table was…

### DIFF
--- a/EOSlib.c
+++ b/EOSlib.c
@@ -24,7 +24,7 @@ EOSMATERIAL *EOSinitMaterial(int iMat, double dKpcUnit, double dMsolUnit, const 
 	EOSMATERIAL *material;
 	material = (EOSMATERIAL *) calloc(1, sizeof(EOSMATERIAL));
 	material->iMat = iMat;
-	material->canDoIsentropic = 0;
+	material->bEntropyTableInit = EOS_FALSE;
 
 	if (iMat == iMATIDEALGAS)
 	{
@@ -50,7 +50,8 @@ EOSMATERIAL *EOSinitMaterial(int iMat, double dKpcUnit, double dMsolUnit, const 
 		material->matType = EOSANEOS;
 		material->ANEOSmaterial = ANEOSinitMaterial(iMat, dKpcUnit, dMsolUnit);
 		material->rho0 = ANEOSgetRho0(material->ANEOSmaterial);
-		material->canDoIsentropic = 1;
+        // The entropy look up table is initialized in ANEOSinitMaterial
+		material->bEntropyTableInit = EOS_TRUE;
 		material->minSoundSpeed = ANEOSCofRhoT(material->ANEOSmaterial, material->rho0, 1e-4);
 	}
 	
@@ -69,10 +70,11 @@ void EOSinitIsentropicLookup(EOSMATERIAL *material, const void * additional_data
 			break;
 		case EOSTILLOTSON:
 			tillInitLookup(material->tillmaterial, 1000, 1000, 1e-4, 200.0, 1200.0);
-			material->canDoIsentropic = 1;
+			material->bEntropyTableInit = EOS_TRUE;
 			break;
 		case EOSANEOS:
 			// nothing to do
+            if (material->bEntropyTableInit != EOS_TRUE) material->bEntropyTableInit = EOS_TRUE;
 			break;
 		default:
 		assert(0);

--- a/EOSlib.h
+++ b/EOSlib.h
@@ -42,7 +42,7 @@ typedef struct EOSmaterial
 	int iMat; // Material number
 	int matType; // Material type, 0: Tillotson, 1: ANEOS
 	double rho0; // reference density
-	int canDoIsentropic; // flag to signal if isentropic evolution is availlable
+	int bEntropyTableInit; // flag to signal if the entropy table is initialized
 	double minSoundSpeed; // sound speed at reference values
 	TILLMATERIAL *tillmaterial; // Pointer to tillotson material
 	ANEOSMATERIAL *ANEOSmaterial; // Pointer to ANEOS material


### PR DESCRIPTION
Added a flag bEntropyTableInit which is FALSE if no entropy table was initialized and TRUE if it is. For ANEOS (or other EOS that contain entropy information) the flag is set to true in initMaterial.